### PR TITLE
Fix draw performance when adding data points

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "streamhub-map",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": [
     "./src/main.js"
   ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "cheung31"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "devDependencies": {
     "bower": "~1.0.0",
     "http-server": "*",


### PR DESCRIPTION
Add a cluster config option for MapView. Fix bug of redrawing map each time map needs updating. Only redraw map when 'mapResizing.hub' event triggered
